### PR TITLE
Bump to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>ng-tags-input</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <name>ngTagsInput</name>
     <description>WebJar for ngTagsInput</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.0.1</upstream.version>
+        <upstream.version>2.1.1</upstream.version>
         <upstream.url>https://cdnjs.cloudflare.com/ajax/libs/ng-tags-input/${upstream.version}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>


### PR DESCRIPTION
Bumping ng-tags-input to 2.1.1

As per: https://github.com/mbenford/ngTagsInput/releases
